### PR TITLE
[OCB] Use d2-analytics local development folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/dhis2/event-reports-app#readme",
   "dependencies": {
-    "d2-analysis": "^33.3.4",
+    "d2-analysis": "../d2-analysis",
     "d2-utilizr": "0.2.13"
   },
   "devDependencies": {
@@ -53,6 +53,7 @@
     "webpack-dev-server": "1.14.0"
   },
   "manifest.webapp": {
+    "core_app": true,
     "short_name": "event-reports",
     "name": "DHIS2 event reports app",
     "icons": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "event-reports-app",
-  "version": "33.3.4",
+  "version": "33.3.4-ocb-1",
   "description": "Event reports app",
   "main": "index.html",
   "scripts": {

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -10,10 +10,6 @@ webpackBaseConfig.plugins = [
     }),
     new webpack.optimize.DedupePlugin(),
     new webpack.optimize.OccurenceOrderPlugin(),
-    new webpack.optimize.UglifyJsPlugin({
-        minimize: true,
-        sourceMap: true,
-    }),
 ];
 
 module.exports = webpackBaseConfig;


### PR DESCRIPTION
Required by https://app.clickup.com/t/8699fh2aa

https://app.clickup.com/t/8699fh2aa?comment=90120139926139

- [x] Infrastructure to support dev d2-analysis

Example of build.sh:

```
#!/bin/bash
set -e -u -o pipefail

version=$(jq <package.json -r '.version')
(cd ../d2-analysis && yarn build)
yarn build
(cd build && zip -r ../events-reports-app-"$version".zip .)
```