### PR TITLE
[OCA][Fix] XLS download fails with API error

### DIFF
--- a/i18n/i18n_app.properties
+++ b/i18n/i18n_app.properties
@@ -340,3 +340,4 @@ last_4_biweeks=Last 4 bi-weeks
 pivot_table=Pivot table
 line_list=Line list
 table_style=Table style
+table_render_failed=Table could not be rendered. Try reducing dimensions.

--- a/i18n/i18n_app_nl.properties
+++ b/i18n/i18n_app_nl.properties
@@ -340,3 +340,4 @@ last_4_biweeks=Last 4 bi-weeks
 pivot_table=Pivot table
 line_list=Line list
 table_style=Table style
+table_render_failed=Tabel kan niet worden weergegeven. Probeer dimensies te verminderen.

--- a/src/api/Layout.js
+++ b/src/api/Layout.js
@@ -378,7 +378,7 @@ Layout.prototype.req = function(source, format, isSorted, isTableLayout, isFilte
         request.add('tableLayout=true');
 
         // id scheme
-        request.add('dataIdScheme=NAME');
+        request.add('dataIdScheme=CODE');
 
         // columns
         //request.add('columns=' + this.getDimensionNames(false, false, this.columns).join(';'));

--- a/src/index.js
+++ b/src/index.js
@@ -150,13 +150,13 @@ function initialize() {
         };
 
         const handleRenderError = (error) => {
-            console.error("Event report render failed with", error);
+            console.error('Event report render failed with', error);
             uiManager.update();
-            uiManager.removeScrollFn("centerRegion");
-            uiManager.removeResizeFn("centerRegion");
+            uiManager.removeScrollFn('centerRegion');
+            uiManager.removeResizeFn('centerRegion');
             uiManager.alert({
-                status: "ERROR",
-                message: i18nManager.get("table_render_failed")
+                status: 'ERROR',
+                message: i18nManager.get('table_render_failed')
             });
         };
 

--- a/src/index.js
+++ b/src/index.js
@@ -158,6 +158,8 @@ function initialize() {
                 status: 'ERROR',
                 message: i18nManager.get('table_render_failed')
             });
+            // Remove loading mask
+            uiManager.unmask();
         };
 
         let createPivotTable = function(layout, response) {
@@ -191,11 +193,11 @@ function initialize() {
                 } else {
                     renderTable(_table, layout, sortingId);
                 }
+
+                afterLoad();
             } catch (error) {
                 handleRenderError(error);
             }
-
-            afterLoad();
         };
 
         var createEventDataTable = function(layout, response) {

--- a/src/index.js
+++ b/src/index.js
@@ -149,6 +149,17 @@ function initialize() {
             instanceManager.postDataStatistics();
         };
 
+        const handleRenderError = (error) => {
+            console.error("Event report render failed with", error);
+            uiManager.update();
+            uiManager.removeScrollFn("centerRegion");
+            uiManager.removeResizeFn("centerRegion");
+            uiManager.alert({
+                status: "ERROR",
+                message: i18nManager.get("table_render_failed")
+            });
+        };
+
         let createPivotTable = function(layout, response) {
 
             let statusBar = uiManager.get('statusBar');
@@ -165,19 +176,23 @@ function initialize() {
                 layout.sort();
             }
 
-            let _table = new table.PivotTable(refs, layout, response, tableOptions);
+            try {
+                let _table = new table.PivotTable(refs, layout, response, tableOptions);
 
-            if (_table.doClipping()) {
-                uiManager.confirmRender(
-                    `Table size warning`,
-                    () => renderTable(_table, layout, sortingId),
-                    () =>  {
-                        uiManager.update();
-                        uiManager.unmask();
-                    }
-                );
-            } else {
-                renderTable(_table, layout, sortingId);
+                if (_table.doClipping()) {
+                    uiManager.confirmRender(
+                        `Table size warning`,
+                        () => renderTable(_table, layout, sortingId),
+                        () =>  {
+                            uiManager.update();
+                            uiManager.unmask();
+                        }
+                    );
+                } else {
+                    renderTable(_table, layout, sortingId);
+                }
+            } catch (error) {
+                handleRenderError(error);
             }
 
             afterLoad();


### PR DESCRIPTION
### Refs
 
- [[7] Issue with DHIS2 Event Report App – XLS Download and Hep C Dataset](https://app.clickup.com/t/4528615/869deqqxr)

### Description

When trying to download a table with DEs with _valueType Yes/No_ the API fails with a `NullPointerException`.
The issue was fixed in DHIS2.40.11, but as we cant change versions this fix modifies the call parameter `dataIdScheme` to use CODE instead of NAME.

Additionally, a error window was added for d2-analysis `PivotTableAxis` exceptions, as they result in a endless loading.

Intended to be used with: [d2-analysis#37](https://github.com/EyeSeeTea/d2-analysis/pull/37)

#869deqqxr